### PR TITLE
created a new class for 2.5d interpolation, and its example

### DIFF
--- a/examples/example_specfem_tomo_helper_2p5D.py
+++ b/examples/example_specfem_tomo_helper_2p5D.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+
+from specfem_tomo_helper.projection import vp2rho, vp2vs, define_utm_projection
+from specfem_tomo_helper.fileimport import Nc_model
+from specfem_tomo_helper.utils import maptool, write_tomo_file,linear_interpolator1d2d
+import subprocess
+import os
+import numpy as np
+from scipy.interpolate import interp1d
+import matplotlib.pyplot as plt
+
+path = '../data/Alaska.JointInversion-RF+Vph+HV-1.Berg.2020-nc4.nc'
+
+if not os.path.isfile(path):
+    subprocess.call(['wget', '-P', '../data/', 'http://ds.iris.edu/files/products/emc/emc-files/Alaska.JointInversion-RF+Vph+HV-1.Berg.2020-nc4.nc'])
+
+# Mandatory inputs:
+dy = 3000  # in m
+dx = 3000  # in m
+# In the 2D interpolation scheme, each depth value of the model is used as depth value. Therefore there is no dz parameters.
+z_min = -34 # in km
+z_max = -8 # in km
+dz=3000 # in meters
+# load netCDF model
+nc_model = Nc_model(path)
+# extract coordinates
+lon, lat, depth = nc_model.load_coordinates()
+# Load the 3 model parameters from the netCDF model
+vp = nc_model.load_variable('vpfinal', fill_nan=True)
+vs = nc_model.load_variable('vsfinal', fill_nan=True)
+rho = nc_model.load_variable('rhofinal', fill_nan=True)
+# flip the model 
+if nc_model.dataset.id=='Alaska.JointInversion_RF+Vph+HV-1.Berg.2020':
+    vp.values=np.flipud(vp.values)
+    vs.values=np.flipud(vs.values)
+    rho.values=np.flipud(rho.values*1000)
+# fill_nan is set to True here, as the shallow layers of the model contain nan values
+
+# define pyproj custom projection. 
+myProj = define_utm_projection(6, 'N')
+
+# Here are two example modes possible (1 or 2)
+# 1 for direct input, 2 for GUI map input
+mode = 1
+if mode == 1:
+    # Direct input akin to specfem Mesh_Par_File
+    latitude_min                    = 7003782.0
+    latitude_max                    = 7353782.0
+    longitude_min                   = 194682.2
+    longitude_max                   = 594682.2
+    # Initialize interpolator with model and UTM projection
+    interpolator = linear_interpolator1d2d(nc_model, myProj)
+    interpolator.interpolation_parameters(longitude_min, longitude_max, dx,
+                                          latitude_min, latitude_max, dy,
+                                          z_min, z_max,dz)
+
+if mode == 2:
+    # Second mode with graphical area selection for interpolation.
+    # The GUI window might freeze during the interpolation, instead of closing. Don't panic!
+    gui_parameters = maptool(nc_model, myProj)
+    interpolator = linear_interpolator1d2d(nc_model, myProj)
+    interpolator.interpolation_parameters(
+        gui_parameters.extent[0], gui_parameters.extent[1], dx,
+        gui_parameters.extent[2], gui_parameters.extent[3], dy,
+        z_min, z_max,dz)
+
+# Compute the tomography array and perform 2.5d interpolation
+tomo = interpolator.interpolate([vp, vs, rho])
+
+
+
+# Write the tomography_file.xyz in "./" directory. It uses the tomography array and the interpolator parameters to produce the HEADER.
+write_tomo_file(tomo, interpolator, './')

--- a/examples/example_specfem_tomo_helper_2p5D.py
+++ b/examples/example_specfem_tomo_helper_2p5D.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+# example provided for 2.5d interpolation for 
 from specfem_tomo_helper.projection import vp2rho, vp2vs, define_utm_projection
 from specfem_tomo_helper.fileimport import Nc_model
 from specfem_tomo_helper.utils import maptool, write_tomo_file,linear_interpolator1d2d
@@ -26,14 +26,10 @@ nc_model = Nc_model(path)
 # extract coordinates
 lon, lat, depth = nc_model.load_coordinates()
 # Load the 3 model parameters from the netCDF model
-vp = nc_model.load_variable('vpfinal', fill_nan=True)
-vs = nc_model.load_variable('vsfinal', fill_nan=True)
-rho = nc_model.load_variable('rhofinal', fill_nan=True)
-# flip the model 
-if nc_model.dataset.id=='Alaska.JointInversion_RF+Vph+HV-1.Berg.2020':
-    vp.values=np.flipud(vp.values)
-    vs.values=np.flipud(vs.values)
-    rho.values=np.flipud(rho.values*1000)
+vp = nc_model.load_variable('vpfinal', fill_nan='vertical')
+vs = nc_model.load_variable('vsfinal', fill_nan='vertical')
+rho = nc_model.load_variable('rhofinal', fill_nan='vertical')
+
 # fill_nan is set to True here, as the shallow layers of the model contain nan values
 
 # define pyproj custom projection. 

--- a/specfem_tomo_helper/fileimport/ncimport.py
+++ b/specfem_tomo_helper/fileimport/ncimport.py
@@ -66,6 +66,13 @@ class Nc_model:
             var_data[var_mask] = np.nan
         if dims == ('depth', 'latitude', 'longitude'):
             var_data = np.rot90(var_data.T,k=1)
+        
+        if self.dataset.id=='Alaska.JointInversion_RF+Vph+HV-1.Berg.2020':
+            var_data=np.flipud(var_data) # adapt for berg2020 model
+
+        if varname=='rhofinal' and np.nanmean(var_data[:,:,0])<100:
+            print('converting rho')
+            var_data=var_data*1000
 
         if fill_nan == 'vertical':
             for depth_id in len(self.depth)-2-np.arange(len(self.depth)-1):

--- a/specfem_tomo_helper/utils/__init__.py
+++ b/specfem_tomo_helper/utils/__init__.py
@@ -3,4 +3,5 @@
 from specfem_tomo_helper.utils.graphical_area_selec import maptool
 from specfem_tomo_helper.utils.interpolator2d import bilinear_interpolator
 from specfem_tomo_helper.utils.interpolator3d import trilinear_interpolator
+from specfem_tomo_helper.utils.interpolator2p5d import linear_interpolator1d2d
 from specfem_tomo_helper.utils.io import write_tomo_file

--- a/specfem_tomo_helper/utils/interpolator2p5d.py
+++ b/specfem_tomo_helper/utils/interpolator2p5d.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+import numpy as np
+import pandas as pd
+import scipy.interpolate
+from scipy.interpolate import interp1d
+
+class linear_interpolator1d2d():
+    """ 1D+2D interpolator. """
+
+    def __init__(self, model, projection):
+        # Initialise the various paramters of the interpolator, mainly the coordinates that will be used later.
+        self.utm_x = None
+        self.utm_y = None
+        self.tomo_xyz = []
+        self.lon, self.lat, self.depth = model.load_coordinates()
+        self.x, self.y = np.meshgrid(self.lon, self.lat, indexing='ij')
+        utm_x, utm_y = projection(self.x, self.y)
+        self.utm_x = utm_x.flatten()
+        self.utm_y = utm_y.flatten()
+
+    def interpolation_parameters(self, xspecfem_min, xspecfem_max, dx, yspecfem_min, yspecfem_max, dy, zspecfem_min, zspecfem_max, dz):
+        """ Initialise the interpolation grid from a set of coordinates parameters. """
+        # xspecfem_min/max corresponds to the Longitude min/max in Mesh_Par_File
+        self.xspecfem_min = xspecfem_min
+        self.xspecfem_max = xspecfem_max
+        # dx is the easting sampling rate in m
+        self.dx = dx
+        # yspecfem_min/max corresponds to the Latitude min/max in Mesh_Par_File
+        self.yspecfem_min = yspecfem_min
+        self.yspecfem_max = yspecfem_max
+        # dy is the northing sampling rate in m
+        self.dy = dy
+        # zmin and zmax are the desired interpolation bounds in km. zmin should be the positive topographic values (the "top" of the model), zmax is the maximum depth (should be negative in the vast majorities of instances).
+        self.zmin = zspecfem_min
+        self.zmax = zspecfem_max
+        # dz is the depth sampling rate in m
+        self.dz = dz
+        # Here are defined the interpolation coordinates as a regular grid in utm coordinates.
+        self.x_interp_coordinates = np.arange(self.xspecfem_min-self.dx,
+                                              self.xspecfem_max+self.dx*2, self.dx)
+        self.y_interp_coordinates = np.arange(self.yspecfem_min-self.dy,
+                                              self.yspecfem_max+self.dy*2, self.dy)
+        self.z_interp_coordinates = np.flip(np.arange(self.zmax*1e3, self.zmin*1e3+self.dz, -self.dz))
+        # Create the meshgrid from the previously computed coordinates
+        Z, Y, X = np.meshgrid(self.z_interp_coordinates,
+                              self.y_interp_coordinates,
+                              self.x_interp_coordinates, indexing='ij')
+        # Transform the (nz, ny, nx) meshgrid arrays, to 3 vectors.
+        self.Y_grid = Y.flatten()
+        self.X_grid = X.flatten()
+        self.Z_grid = Z.flatten()
+
+    def interpolation_grid(self):
+        """ This function can be used if you wish to simply return the interpolation grid coordinates (only the easting and northing). It might be useful to vizualise the interpolation points on a map. """
+        self.x_interp_coordinates = np.arange(self.xspecfem_min-self.dx,
+                                              self.xspecfem_max+self.dx*2, self.dx)
+        self.y_interp_coordinates = np.arange(self.yspecfem_min-self.dy,
+                                              self.yspecfem_max+self.dy*2, self.dy)
+        Y, X = np.meshgrid(self.y_interp_coordinates, self.x_interp_coordinates, indexing='ij')
+        self.Y_grid = Y.flatten()
+        self.X_grid = X.flatten()
+        return (self.x_interp_coordinates, self.y_interp_coordinates)
+
+
+    def interpolate(self,model_param):
+        if not type(model_param) is list:
+            model_param = [model_param]
+        param_names = [param.name for param in model_param]
+
+        z_coordinates = []
+
+        model_pad_y = np.diff(self.lat[0:2])[0]*111000
+        model_pad_x = np.diff(self.lon[0:2])[0]*111000
+
+        for depth_id, depth_val in enumerate(self.depth):
+            if depth_val <= self.zmax and depth_val >= self.zmin:
+                print(depth_id, depth_val)
+                z_coordinates.append(depth_val)
+                z_model_slices = [param.values[:, :, depth_id].T.flatten() for param in model_param]
+                Z_grid = np.ones_like(self.X_grid)*depth_val*1e3
+                data_array = np.vstack(
+                    (self.x.flatten(), self.y.flatten(), z_model_slices, self.utm_x, self.utm_y)).T
+                frame = pd.DataFrame(data=data_array, columns=[
+                                     'lon', 'lat'] + param_names + ['utm_x', 'utm_y'])
+
+                df = frame[(frame['utm_y'] >= self.Y_grid.min()-model_pad_y) & (frame['utm_y'] <= self.Y_grid.max()+model_pad_y) & (
+                    frame['utm_x'] >= self.X_grid.min()-model_pad_x) & (frame['utm_x'] <= self.X_grid.max()+model_pad_x)]
+
+                utm_xy = np.vstack((df['utm_x'], df['utm_y'])).T
+                filtered_model_param = np.asarray(df[param_names]).T
+                interpolated_params = [scipy.interpolate.LinearNDInterpolator(utm_xy, param)(
+                    self.X_grid, self.Y_grid)
+                    for param in filtered_model_param]
+
+                slice_interpolated_map = np.vstack(
+                    (self.X_grid, self.Y_grid, Z_grid, interpolated_params)).T
+                self.tomo_xyz.insert(0, slice_interpolated_map)
+        self.tomo_xyz = np.concatenate(self.tomo_xyz)
+
+        nlay=len(self.x_interp_coordinates)*len(self.y_interp_coordinates)
+        dep_int=np.unique(self.z_interp_coordinates)*1000
+        tomo_lay=np.empty((nlay,3+len(param_names),len(dep_int)))
+        for i,dep,in enumerate(dep_int):
+            tomo_lay[:,:,i]=self.tomo_xyz[i*nlay:(i+1)*nlay,:]
+        tomo_lay=np.swapaxes(tomo_lay,1,2)
+        #interp with new depth
+        self.tomo_xyz=np.empty((nlay,len(self.z_interp_coordinates),6))
+        f_dep_interp=interp1d(dep_int,tomo_lay,axis=1)
+        for i,zint in enumerate(dep_int):
+            self.tomo_xyz[:,i,:]=f_dep_interp(zint)
+        self.tomo_xyz= self.tomo_xyz.reshape(-1, self.tomo_xyz.shape[-1],order='F')
+        return self.tomo_xyz


### PR DESCRIPTION
The new files are written alongside of the original package, the old interpolator remain untouched. Only modified specfem_tomo_helper/utils/__init__.py.
The new class works alike bilinear_interpolator, but the output is like trilinear_interpolator. The interpolation is performed like 2d firstly, then it perform 1d interpolation for the third dimension. By doing this, we can get an interpolated tomography model at any depth and avoid long waiting time of the 3d interpolator. 